### PR TITLE
Custody dd fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -36,16 +36,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash 0.7.6",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -67,6 +67,8 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "smallvec",
+ "tokio",
+ "tokio-util 0.7.7",
  "tracing",
  "zstd",
 ]
@@ -78,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -96,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
+checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -107,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -146,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+checksum = "464e0fddc668ede5f26ec1f9557a8d44eda948732f40c6b0ad79126930eb775f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -181,7 +183,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.17",
+ "time 0.3.19",
  "url",
 ]
 
@@ -192,9 +194,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -255,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.8",
@@ -300,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayvec"
@@ -348,13 +350,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -407,7 +409,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "regex",
  "rustc-hash",
@@ -505,8 +507,8 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.49",
- "syn 1.0.107",
+ "proc-macro2 1.0.51",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -515,9 +517,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -526,9 +528,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -544,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -560,9 +562,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
@@ -578,9 +580,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytestring"
@@ -593,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -606,7 +608,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -672,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -706,9 +708,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -731,20 +733,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "concat-idents"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe0e1d9f7de897d18e590a7496b5facbe87813f746cf4b8db596ba77e07e832"
 dependencies = [
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -784,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.17",
+ "time 0.3.19",
  "version_check",
 ]
 
@@ -889,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -901,34 +914,34 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "scratch",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -941,7 +954,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -970,10 +983,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -996,16 +1009,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.8.0"
+name = "dotenv"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1117,32 +1136,11 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fawkes-crypto"
-version = "4.3.4"
-source = "git+https://github.com/zkBob/fawkes-crypto?branch=multicore-wasm#58629f1a8d1f153bcb5895a455b3e23b533ecde0"
-dependencies = [
- "bit-vec",
- "blake2-rfc_bellman_edition",
- "borsh",
- "brotli",
- "byteorder",
- "fawkes-crypto-bellman_ce",
- "fawkes-crypto_derive",
- "ff-uint",
- "getrandom 0.2.8",
- "impl-trait-for-tuples 0.1.3",
- "itertools",
- "linked-list",
- "rand 0.7.3",
- "serde 1.0.152",
 ]
 
 [[package]]
@@ -1168,19 +1166,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "fawkes-crypto-zkbob"
+version = "4.5.0"
+source = "git+https://github.com/zkBob/fawkes-crypto?branch=master#a893c53592de1ec4b990a44347567caeb180f9f0"
+dependencies = [
+ "bit-vec",
+ "blake2-rfc_bellman_edition",
+ "borsh",
+ "brotli",
+ "byteorder",
+ "fawkes-crypto-bellman_ce",
+ "fawkes-crypto_derive",
+ "ff-uint",
+ "getrandom 0.2.8",
+ "impl-trait-for-tuples 0.1.3",
+ "itertools",
+ "linked-list",
+ "rand 0.7.3",
+ "serde 1.0.152",
+]
+
+[[package]]
+name = "fawkes-crypto-zkbob-keccak256"
+version = "0.1.1"
+source = "git+https://github.com/zkbob/keccak?branch=master#5112b2e188e400962685266c2ced2f2e9917d51e"
+dependencies = [
+ "fawkes-crypto-zkbob",
+ "hex 0.3.2",
+]
+
+[[package]]
 name = "fawkes-crypto_derive"
 version = "4.3.0"
-source = "git+https://github.com/zkBob/fawkes-crypto?branch=multicore-wasm#58629f1a8d1f153bcb5895a455b3e23b533ecde0"
+source = "git+https://github.com/zkBob/fawkes-crypto?branch=master#a893c53592de1ec4b990a44347567caeb180f9f0"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "ff-uint"
 version = "0.2.4"
-source = "git+https://github.com/zkBob/fawkes-crypto?branch=multicore-wasm#58629f1a8d1f153bcb5895a455b3e23b533ecde0"
+source = "git+https://github.com/zkBob/fawkes-crypto?branch=master#a893c53592de1ec4b990a44347567caeb180f9f0"
 dependencies = [
  "borsh",
  "byteorder",
@@ -1199,15 +1227,15 @@ dependencies = [
 [[package]]
 name = "ff-uint_derive"
 version = "0.2.4"
-source = "git+https://github.com/zkBob/fawkes-crypto?branch=multicore-wasm#58629f1a8d1f153bcb5895a455b3e23b533ecde0"
+source = "git+https://github.com/zkBob/fawkes-crypto?branch=master#a893c53592de1ec4b990a44347567caeb180f9f0"
 dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits 0.2.15",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -1320,9 +1348,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1335,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1345,15 +1373,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1362,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1383,26 +1411,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -1412,9 +1440,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1491,7 +1519,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -1553,15 +1581,15 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
- "spin 0.9.4",
+ "spin 0.9.5",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1604,9 +1632,9 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1665,9 +1693,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1773,7 +1801,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.2.1",
+ "parity-scale-codec 3.4.0",
 ]
 
 [[package]]
@@ -1800,9 +1828,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -1811,9 +1839,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -1879,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2019,13 +2047,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libzeropool"
-version = "0.5.7"
-source = "git+https://github.com/zkBob/libzeropool?branch=multicore-wasm#ed99580a4091560c83c973a804cdb7485043a691"
+name = "libzeropool-zkbob"
+version = "1.1.0"
+source = "git+https://github.com/zkbob/libzeropool-zkbob?branch=master#1e0de98148361b8d6b42f74f362ad023945a2a96"
 dependencies = [
  "chacha20poly1305",
  "convert_case",
- "fawkes-crypto",
+ "fawkes-crypto-zkbob",
+ "fawkes-crypto-zkbob-keccak256",
  "lazy_static",
  "serde 1.0.152",
  "serde_json",
@@ -2034,18 +2063,19 @@ dependencies = [
 
 [[package]]
 name = "libzkbob-rs"
-version = "0.8.0"
-source = "git+https://github.com/zkBob/libzkbob-rs?branch=custody#4eb9e5cf2af5e994695262abed3c37eb78b5b6d4"
+version = "1.0.0"
+source = "git+https://github.com/zkBob/libzkbob-rs?branch=custody#63784ed92ce5bd3fb4430af4471d9e9083714ffa"
 dependencies = [
  "base64 0.13.1",
  "borsh",
  "bs58",
  "byteorder",
  "getrandom 0.2.8",
+ "hex 0.4.3",
  "kvdb",
  "kvdb-memorydb",
  "kvdb-rocksdb",
- "libzeropool",
+ "libzeropool-zkbob",
  "serde 1.0.152",
  "sha3 0.10.6",
  "thiserror",
@@ -2120,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -2133,10 +2163,13 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "memo-parser"
 version = "0.2.0"
-source = "git+https://github.com/zkBob/memo-parser?branch=develop#e0afbde03874153f0cd1952a2bf344fd13d4266d"
+source = "git+https://github.com/zkBob/memo-parser?branch=main#f121526ffcc8bf7149fe97535abc6f566013cdc3"
 dependencies = [
+ "bs58",
  "chrono",
  "clap",
+ "colored",
+ "dotenv",
  "hex 0.4.3",
  "thousands",
  "tokio",
@@ -2175,14 +2208,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2222,12 +2255,21 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2313,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -2344,9 +2386,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -2488,15 +2530,15 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples 0.2.2",
- "parity-scale-codec-derive 3.1.3",
+ "parity-scale-codec-derive 3.1.4",
  "serde 1.0.152",
 ]
 
@@ -2506,22 +2548,22 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate 1.2.1",
- "proc-macro2 1.0.49",
+ "proc-macro-crate 1.3.0",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
- "proc-macro-crate 1.2.1",
- "proc-macro2 1.0.49",
+ "proc-macro-crate 1.3.0",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -2544,8 +2586,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.49",
- "syn 1.0.107",
+ "proc-macro2 1.0.51",
+ "syn 1.0.108",
  "synstructure",
 ]
 
@@ -2573,7 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -2592,15 +2634,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2636,9 +2678,9 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -2713,13 +2755,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2729,9 +2770,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
  "version_check",
 ]
 
@@ -2741,7 +2782,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "version_check",
 ]
@@ -2757,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2779,7 +2820,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
 ]
 
 [[package]]
@@ -2905,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2948,9 +2989,9 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9c0c92af03644e4806106281fe2e068ac5bc0ae74a707266d06ea27bccee5f"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -3000,7 +3041,6 @@ dependencies = [
  "kvdb",
  "kvdb-memorydb",
  "kvdb-rocksdb",
- "libzeropool",
  "libzkbob-rs",
  "memo-parser",
  "num-bigint 0.4.3",
@@ -3041,11 +3081,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3182,7 +3222,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3227,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3240,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3251,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "seedbox"
 version = "0.2.0"
-source = "git+https://github.com/zkBob/fawkes-crypto?branch=multicore-wasm#58629f1a8d1f153bcb5895a455b3e23b533ecde0"
+source = "git+https://github.com/zkBob/fawkes-crypto?branch=master#a893c53592de1ec4b990a44347567caeb180f9f0"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -3308,16 +3348,16 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3410,18 +3450,18 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3465,9 +3505,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -3509,11 +3549,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
  "unicode-ident",
 ]
@@ -3524,9 +3564,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
  "unicode-xid 0.2.4",
 ]
 
@@ -3552,9 +3592,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3566,9 +3606,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e5f048404b43e8ae66dce036163515b6057024cf58c6377be501f250bd3c6a"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
  "version_check",
 ]
 
@@ -3593,9 +3633,9 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -3606,10 +3646,11 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -3648,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde 1.0.152",
@@ -3666,9 +3707,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -3693,15 +3734,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3714,7 +3755,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3723,16 +3764,16 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3751,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3777,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3792,11 +3833,28 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde 1.0.152",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -3836,9 +3894,9 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
 ]
 
 [[package]]
@@ -3847,12 +3905,12 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78fa7c4b548e5c79a0300396f36f175da001e9933dfb5960b326db25fddbaee7"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
  "gethostname",
  "log",
  "serde 1.0.152",
  "serde_json",
- "time 0.3.17",
+ "time 0.3.19",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -3948,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -4015,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
  "rand 0.8.5",
@@ -4077,9 +4135,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4087,24 +4145,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4114,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote 1.0.23",
  "wasm-bindgen-macro-support",
@@ -4124,28 +4182,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.49",
+ "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.107",
+ "syn 1.0.108",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4217,7 +4275,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "url",
  "web3-async-native-tls",
 ]
@@ -4289,6 +4347,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -4404,18 +4486,18 @@ checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.4+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4423,9 +4505,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.5+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde-aux = "2.3.0"
 #web3="0.18.0" https://github.com/tomusdrw/rust-web3/pull/651
 web3={git = "https://github.com/r0wdy1/rust-web3", branch = "logs_txhash" }
 tokio={version="1.17", features=["rt","rt-multi-thread","sync"]}
-libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "multicore-wasm", version = "0.5.6", default-features = false, features = ["in3out127"] }
 borsh = "0.9.1"
 # libzkbob-rs = {version = "0.7.0", features = ["native"]}
 libzkbob-rs = {git = "https://github.com/zkBob/libzkbob-rs", branch = "custody", features = ["native"]}
@@ -36,7 +35,7 @@ secp256k1 = "0.21"
 ethabi = "17.1.0"
 kvdb-rocksdb = "0.11.0"
 env_logger = "0.9.0"
-memo-parser = {git = "https://github.com/zkBob/memo-parser", branch = "develop"}
+memo-parser = {git = "https://github.com/zkBob/memo-parser", branch = "main"}
 # memo-parser = {path = "../memo-parser"}
 hex = { version = "0.4.3", features = ["serde"] }
 num-bigint = "0.4"

--- a/configuration/docker.yaml
+++ b/configuration/docker.yaml
@@ -8,7 +8,7 @@ application:
     params: params/tree_params.bin
 web3:
   provider_endpoint: http://host.docker.internal:8545
-  pool_address: 0xe982E462b094850F12AF94d21D470e21bE9D0E9C
+  pool_address: 0290FB167208Af455bB137780163b7B7a9a10C16
   relayer_fee: 100000000
   credentials:
     secret_key: 6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c

--- a/configuration/staging.yaml
+++ b/configuration/staging.yaml
@@ -8,7 +8,7 @@ application:
     params: params/tree_params.bin
 web3:
   provider_endpoint: https://rpc.sepolia.org
-  pool_address: 3bd088C19960A8B5d72E4e01847791BD0DD1C9E6
+  pool_address: 0x3bd088C19960A8B5d72E4e01847791BD0DD1C9E6
   start_block: 1793710
   relayer_fee: 100000000
 custody:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,12 +9,11 @@ services:
       - ../configuration:/app/configuration
       - ../data:/app/data
     environment:
-      APP_ENVIRONMENT: $APP_ENVIRONMENT
-      RUST_LOG: $RUST_LOG
+      APP_ENVIRONMENT: staging
+      RUST_LOG: info
       RUST_BACKTRACE: 1
     ports:
       - 8001:8001
-      - 80:80
     restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -110,7 +110,7 @@ pub struct TRMSettings {
     pub api_key: String
 }
 
-use libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier, Parameters};
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier, Parameters};
 
 use crate::custody::config::CustodyServiceSettings;
 

--- a/src/custody/helpers.rs
+++ b/src/custody/helpers.rs
@@ -1,4 +1,4 @@
-use libzeropool::fawkes_crypto::ff_uint::Num;
+use libzkbob_rs::libzeropool::fawkes_crypto::ff_uint::Num;
 
 use super::types::Fr;
 

--- a/src/custody/routes.rs
+++ b/src/custody/routes.rs
@@ -5,7 +5,7 @@ use actix_web::{
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use kvdb::KeyValueDB;
 use kvdb_rocksdb::Database;
-use libzeropool::{fawkes_crypto::{
+use libzkbob_rs::libzeropool::{fawkes_crypto::{
     backend::bellman_groth16::{engines::Bn256, Parameters},
 }, constants::OUT};
 

--- a/src/custody/routes.rs
+++ b/src/custody/routes.rs
@@ -131,7 +131,12 @@ pub async fn transfer<D: KeyValueDB>(
     custody_db: Data<Database>,
     prover_sender: Data<Sender<ScheduledTask<D>>>,
     callback_sender: Data<Sender<JobStatusCallback>>,
+    bearer: BearerAuth,
 ) -> Result<HttpResponse, CustodyServiceError> {
+    let custody_clone = custody.clone();
+    let custody = custody.write().await;
+    custody.validate_token(bearer.token())?;
+
     let request: TransferRequest = request.0.into();
 
     let account_id = Uuid::from_str(&request.account_id).map_err(|err| {
@@ -139,8 +144,6 @@ pub async fn transfer<D: KeyValueDB>(
         CustodyServiceError::IncorrectAccountId
     })?;
 
-    let custody_clone = custody.clone();
-    let custody = custody.write().await;
     let relayer_url = custody.settings.relayer_url.clone();
     custody.sync_account(account_id, &state).await?;
 

--- a/src/custody/scheduled_task.rs
+++ b/src/custody/scheduled_task.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use actix_web::web::Data;
 use core::fmt::Debug;
 use kvdb::KeyValueDB;
-use libzeropool::fawkes_crypto::{
+use libzkbob_rs::libzeropool::fawkes_crypto::{
     backend::bellman_groth16::{engines::Bn256, Parameters},
     ff_uint::{Num, NumRepr},
 };
@@ -34,7 +34,7 @@ use super::{
     service::{CustodyDbColumn, CustodyService},
     types::Fr,
 };
-use memo_parser::memo::TxType as MemoTxType;
+use memo_parser::calldata::transact::memo::TxType as MemoTxType;
 
 use std::panic::{self, AssertUnwindSafe};
 
@@ -138,7 +138,7 @@ impl<D: KeyValueDB> ScheduledTask<D> {
             let (inputs, proof) = proving_span.in_scope(|| {
                 prove_tx(
                     &self.params,
-                    &*libzeropool::POOL_PARAMS,
+                    &*libzkbob_rs::libzeropool::POOL_PARAMS,
                     tx.public,
                     tx.secret,
                 )

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 use borsh::BorshSerialize;
-use libzeropool::fawkes_crypto::{ff_uint::Num, engines::bn256::Fr};
-use libzeropool::fawkes_crypto::{engines::bn256::Fq, backend::bellman_groth16::{prover::Proof, engines::Bn256}};
-use memo_parser::memo::TxType;
+use libzkbob_rs::libzeropool::fawkes_crypto::{ff_uint::Num, engines::bn256::Fr};
+use libzkbob_rs::libzeropool::fawkes_crypto::{engines::bn256::Fq, backend::bellman_groth16::{prover::Proof, engines::Bn256}};
+use memo_parser::calldata::transact::memo::TxType;
 use num_bigint::{BigInt, ToBigInt};
 
 
@@ -76,8 +76,8 @@ impl BytesRepr for Proof<Bn256> {
     }
 }
 
-pub fn truncate_memo_prefix(tx_type: u32, memo: Vec<u8>) -> Vec<u8> {
-    match TxType::from_u32(tx_type) {
+pub fn truncate_memo_prefix(tx_type: TxType, memo: Vec<u8>) -> Vec<u8> {
+    match tx_type {
         TxType::Deposit => memo[8..].to_vec(),
         TxType::Transfer => memo[8..].to_vec(),
         TxType::Withdrawal => memo[36..].to_vec(),
@@ -87,7 +87,7 @@ pub fn truncate_memo_prefix(tx_type: u32, memo: Vec<u8>) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use libzeropool::fawkes_crypto::{ff_uint::{NumRepr, Num}, engines::{U256, bn256::Fr}};
+    use libzkbob_rs::libzeropool::fawkes_crypto::{ff_uint::{NumRepr, Num}, engines::{U256, bn256::Fr}};
 
     use crate::helpers::BytesRepr;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use relayer_rs::{
     telemetry::setup_telemetry,
 };
 
-use libzeropool::POOL_PARAMS;
+use libzkbob_rs::libzeropool::POOL_PARAMS;
 use libzkbob_rs::merkle::MerkleTree;
 use tokio::sync::{mpsc, Mutex};
 

--- a/src/routes/routes.rs
+++ b/src/routes/routes.rs
@@ -9,7 +9,7 @@ use actix_web::{
 };
 use kvdb::KeyValueDB;
 use kvdb_rocksdb::Database;
-use libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, Parameters};
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, Parameters};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 use crate::{

--- a/src/routes/transactions.rs
+++ b/src/routes/transactions.rs
@@ -3,7 +3,7 @@ use actix_web::{
     HttpResponse,
 };
 use kvdb::KeyValueDB;
-use libzeropool::constants::OUT;
+use libzkbob_rs::libzeropool::constants::OUT;
 use serde::Deserialize;
 
 use crate::{

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,7 +10,7 @@ use crate::{
 use actix_web::{dev::Server, web::Data};
 use kvdb::KeyValueDB;
 
-use libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier::VK};
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier::VK};
 
 use std::{net::TcpListener};
 use tokio::sync::{mpsc::{self, Sender}, RwLock};
@@ -35,6 +35,7 @@ impl<D: 'static + KeyValueDB> Application<D> {
         tracing::info!("using config {:#?}", configuration);
         let vk = vk.unwrap_or(configuration.application.get_tx_vk().unwrap());
         let pool = Pool::new(&configuration.web3).expect("failed to instantiate pool contract");
+        let pool_id = pool.pool_id().await.expect("failed to fetch pool_id");
 
         let state = Data::new(State {
             pending,
@@ -68,6 +69,7 @@ impl<D: 'static + KeyValueDB> Application<D> {
             configuration.custody,
             state.clone(),
             db.clone(),
+            pool_id,
         )));
 
         let server = routes::run(

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,5 +1,5 @@
 use kvdb::KeyValueDB;
-use libzeropool::{
+use libzkbob_rs::libzeropool::{
     constants::{HEIGHT, OUTPLUSONELOG},
     fawkes_crypto::{
         backend::bellman_groth16::{engines::Bn256, prover::Proof, Parameters},

--- a/src/tx_sender.rs
+++ b/src/tx_sender.rs
@@ -1,6 +1,6 @@
 use actix_web::web::Data;
 use kvdb::KeyValueDB;
-use libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, Parameters};
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::{engines::Bn256, Parameters};
 use tokio::{sync::mpsc::{Receiver, error::TryRecvError}, task};
 use web3::types::Transaction;
 use tracing_futures::Instrument;

--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -1,6 +1,7 @@
 use std::time::SystemTime;
 
-use libzeropool::fawkes_crypto::{ff_uint::Num, engines::bn256::Fr};
+use libzkbob_rs::libzeropool::fawkes_crypto::{ff_uint::Num, engines::bn256::Fr};
+use memo_parser::calldata::transact::memo::TxType;
 use serde::{Serialize, Deserialize};
 use uuid::Uuid;
 use web3::types::Transaction as Web3Transaction;
@@ -45,7 +46,7 @@ impl Job {
             .map(|id| Uuid::parse_str(&id).unwrap())
             .unwrap_or(Uuid::new_v4());
 
-        let tx_type = u32::from_str_radix(&transaction_request.tx_type, 16).unwrap();
+        let tx_type = TxType::from_u32(u32::from_str_radix(&transaction_request.tx_type, 16).unwrap());
         let memo = hex::decode(&transaction_request.memo).unwrap();
         let nullifier = transaction_request.proof.inputs[1];
         let commitment = transaction_request.proof.inputs[2];

--- a/src/types/transaction_request.rs
+++ b/src/types/transaction_request.rs
@@ -1,7 +1,7 @@
 use actix_web::web::Data;
 use kvdb::KeyValueDB;
-use libzeropool::fawkes_crypto::{backend::bellman_groth16::{verifier, prover, engines::Bn256}, ff_uint::Num, engines::bn256::Fr};
-use memo_parser::memo::{Memo, TxType};
+use libzkbob_rs::libzeropool::fawkes_crypto::{backend::bellman_groth16::{verifier, prover, engines::Bn256}, ff_uint::Num, engines::bn256::Fr};
+use memo_parser::calldata::transact::memo::{Memo, TxType};
 use serde::{Serialize, Deserialize};
 use uuid::Uuid;
 
@@ -65,7 +65,7 @@ impl TransactionRequest {
             "0003" => TxType::DepositPermittable,
             _ => TxType::Deposit,
         };
-        let parsed_memo = Memo::parse_memoblock(&tx_memo_bytes.unwrap(), tx_type);
+        let parsed_memo = Memo::parse_memoblock(tx_memo_bytes.unwrap(), tx_type);
     
         if parsed_memo.fee < state.settings.web3.relayer_fee {
             tracing::warn!(

--- a/tests/api/generator.rs
+++ b/tests/api/generator.rs
@@ -1,4 +1,4 @@
-use libzeropool::{
+use libzkbob_rs::libzeropool::{
     
     fawkes_crypto::{
         backend::bellman_groth16::{engines::Bn256, Parameters},
@@ -9,7 +9,7 @@ use libzeropool::{
 };
 
 
-use libzeropool::POOL_PARAMS;
+use libzkbob_rs::libzeropool::POOL_PARAMS;
 use libzkbob_rs::proof::prove_tx;
 
 use libzkbob_rs::client::{state::State, TxType, UserAccount};
@@ -106,6 +106,7 @@ impl Generator {
         let state = State::init_test(POOL_PARAMS.clone());
         let acc = UserAccount::new(
             Num::from(rand::thread_rng().gen::<u64>()),
+            Num::ZERO,
             state,
             POOL_PARAMS.clone(),
         );
@@ -129,7 +130,7 @@ impl Generator {
             )
             .unwrap();
 
-        let nullifier: Num<libzeropool::fawkes_crypto::engines::bn256::Fr> =
+        let nullifier: Num<Fr> =
             tx_data.public.nullifier;
         let (inputs, proof) = prove_tx(tx_params, &*POOL_PARAMS, tx_data.public, tx_data.secret);
 

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -3,9 +3,9 @@ use tokio::sync::Mutex;
 use actix_web::web::Data;
 use kvdb_memorydb::InMemory;
 
-use libzeropool::fawkes_crypto::backend::bellman_groth16::verifier::VK;
-use libzeropool::native::params::PoolBN256;
-use libzeropool::POOL_PARAMS;
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::verifier::VK;
+use libzkbob_rs::libzeropool::native::params::PoolBN256;
+use libzkbob_rs::libzeropool::POOL_PARAMS;
 use libzkbob_rs::merkle::MerkleTree;
 use once_cell::sync::Lazy;
 use relayer_rs::configuration::{get_config, Settings};
@@ -18,8 +18,8 @@ use relayer_rs::tx_sender;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{self, Receiver};
 
-use libzeropool::fawkes_crypto::backend::bellman_groth16::setup;
-use libzeropool::{
+use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::setup;
+use libzkbob_rs::libzeropool::{
     circuit::tx::{c_transfer, CTransferPub, CTransferSec},
     fawkes_crypto::{
         backend::bellman_groth16::{engines::Bn256, Parameters},
@@ -29,7 +29,7 @@ use libzeropool::{
 use wiremock::MockServer;
 
 use crate::generator::Generator;
-use libzeropool::fawkes_crypto::circuit::cs::CS;
+use libzkbob_rs::libzeropool::fawkes_crypto::circuit::cs::CS;
 pub struct TestApp {
     pub config: Settings,
     pub address: String,

--- a/tests/api/transactions.rs
+++ b/tests/api/transactions.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use crate::helpers::spawn_app;
 use kvdb::{DBKey, DBOp, DBTransaction, KeyValueDB};
-use libzeropool::constants::OUT;
-use libzeropool::fawkes_crypto::ff_uint::Num;
+use libzkbob_rs::libzeropool::constants::OUT;
+use libzkbob_rs::libzeropool::fawkes_crypto::ff_uint::Num;
 use relayer_rs::{
     custody::types::{
         AccountShortInfo, GenerateAddressResponse, SignupResponse, TransactionStatusResponse,


### PR DESCRIPTION
In this PR the following was done:
1. libzkbob-rs and memo-parser were updated
2. fixed panic during direct deposit sync, now a direct deposit commitment will be saved in mekle tree properly

**Note**: users still can't see and operate with dd notes